### PR TITLE
upgrade to Akka 2.5.x, crossbuild scala 2.11.x and 2.12.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,25 @@
 lazy val root = project.in(file("."))
 
-lazy val akkaV = "2.4.6"
+lazy val akkaV = "2.5.3"
 
 name := "Requester library for Akka"
 
 normalizedName := "requester"
 
-version := "2.6"
+version := "2.7-SNAPSHOT"
+isSnapshot := true
 
 organization := "org.querki"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.10.5", "2.11.8")
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaV,
   "com.typesafe.akka" %% "akka-testkit" % akkaV,
-  "org.scalatest" %% "scalatest" % "2.2.6" % "test",
-  "com.lihaoyi" %% "sourcecode" % "0.1.3"
+  "org.scalatest" %% "scalatest" % "3.0.3" % "test",
+  "com.lihaoyi" %% "sourcecode" % "0.1.4"
 )
   
 homepage := Some(url("http://www.querki.net/"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.16


### PR DESCRIPTION
* upgrade to Akka 2.5.x
* scala crossbuild for 2.11.x and 2.12.x (drops support for 2.10.x because not available for scala 2.5.x)
* sbt upgraded to 0.13.16
* scalatest & sourcelines upgraded (needed for 2.12.x crossbuild) 
